### PR TITLE
Use `safe-date-to-time`

### DIFF
--- a/org-social.el
+++ b/org-social.el
@@ -284,7 +284,7 @@ Argument FOLLOW-LINE text
 	    ;; Extract properties
 	    (when (re-search-forward ":ID:\\s-*\\(.+\\)" post-end t)
 	      (setq id (match-string 1))
-	      (setq date (date-to-time id)))
+	      (setq date (safe-date-to-time id)))
 
 	    (goto-char post-start)
 	    (when (re-search-forward ":MOOD:\\s-*\\(.+\\)" post-end t)


### PR DESCRIPTION
Because sometimes dates can be malformed on other people's timelines, it's better to use `safe-date-to-time` here, which lets the rest of the timeline render.