### PR TITLE
Use safe-date-to-time to avoid parsing errors

### DIFF
--- a/org-social-parser.el
+++ b/org-social-parser.el
@@ -119,7 +119,7 @@ PROP-NAME should be the property name without colons."
 
 	    ;; Extract basic required properties
 	    (setq id (org-social-parser--extract-property properties-text "ID"))
-	    (when id (setq date (date-to-time id)))
+	    (when id (setq date (safe-date-to-time id)))
 
 	    ;; Extract text content (after :END:)
 	    (goto-char post-start)


### PR DESCRIPTION
Continuation of #1 